### PR TITLE
Rewrite and new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+config.ini

--- a/RANes.py
+++ b/RANes.py
@@ -40,14 +40,14 @@ while(status):
         if game_response.status_code == 200:
             game_data = game_response.json()
             print(">Result: {0}".format(game_data["GameTitle"]))
-
-            # Print each key-value pair in the game_data dictionary
-            for key, value in game_data.items():
-                print(f"{key}: {value}")
         else:
             print("Failed to fetch profile data:", response.status_code)
             status = False
             break;
+    else:
+        print("Failed to fetch game data:", game_response.status_code)
+        status = False
+        break;
 
     RPC.update(
         state=data["RichPresenceMsg"],

--- a/RANes.py
+++ b/RANes.py
@@ -1,82 +1,58 @@
-import argparse
-from colorama import Fore, Style, init
-from datetime import datetime
-from pprint import pprint
-from pypresence import Presence 
-import re
+# XtremePrime 2024
+# -- You will need to setup a discord application for this in order to work. To do so, follow the instructions in the README.md
+# -- Please note: This will not be 100% accurate as it only uses latest data from your retro achievements page
+
+import io
 import requests
+import sys
 import time
+from pypresence import Presence 
 
-init(autoreset=True)
+# The first argument of your python call should be your Username, then your API_KEY, then your Discord Application Client ID
+# Ex: 
+# > python RANes.py AverageUser 0X0X0X0X0X0X0X0X 123456789
+USERNAME=str(sys.argv[1])
+API_KEY=str(sys.argv[2])
+RPC_CLIENT_ID = str(sys.argv[3])
 
-def get_data(url):
-    response = requests.get(url)
+profile_url = "https://retroachievements.org/API/API_GetUserProfile.php?u={0}&y={1}&z={2}".format(USERNAME, API_KEY, USERNAME)
+print(profile_url)
+
+RPC = Presence(RPC_CLIENT_ID)
+print(">Connecting to Discord App...")
+RPC.connect()
+print(">Connected")
+
+status = True
+
+while(status):
+    print(">GET profile game activity...")
+    response = requests.get(profile_url)
     if response.status_code == 200:
-        return response.json()
-    else:
-        print(Fore.RED + f"Failed to fetch data from {url}, status code: {response.status_code}")
-        return None
+        data = response.json()
+        print(">Result: {0}".format(data["RichPresenceMsg"]))
 
-def sanitize_console_name(console_name):
-    sanitized_name = re.sub('[^0-9a-zA-Z]+', '', console_name)
-    return sanitized_name.lower()
+        game_params = "?z={0}&y={1}&i={2}".format(USERNAME, API_KEY, data["LastGameID"])
+        game_url = "{0}?{1}".format("https://retroachievements.org/API/API_GetGame.php", game_params)
+        print(">GET game data...")
+        game_response = requests.get(game_url)
 
-def update_presence(RPC, data, game_data, start_time, args):
-    release_date = datetime.strptime(game_data['Released'], '%B %d, %Y')
-    year_of_release = release_date.year
-    details = f"{game_data['GameTitle']} ({year_of_release})"
+        if game_response.status_code == 200:
+            game_data = game_response.json()
+            print(">Result: {0}".format(game_data["GameTitle"]))
+
+            # Print each key-value pair in the game_data dictionary
+            for key, value in game_data.items():
+                print(f"{key}: {value}")
+        else:
+            print("Failed to fetch profile data:", response.status_code)
+            status = False
+            break;
+
     RPC.update(
         state=data["RichPresenceMsg"],
-        details=details,
-        start=start_time,
-        large_image="ra_logo",
-        large_text=f"Released {game_data['Released']}, Developed by {game_data['Developer']}, Published by {game_data['Publisher']}",
-        small_image=sanitize_console_name(game_data['ConsoleName']),
-        small_text=game_data['ConsoleName'],
-        buttons=[{"label": "View RA Profile", "url": f"https://retroachievements.org/user/{args.username}"}]
-    )
+        details=game_data["GameTitle"],
+        )
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument('username')
-    parser.add_argument('api_key')
-    parser.add_argument('--debug', action='store_true')
-    args = parser.parse_args()
-
-    profile_url = f"https://retroachievements.org/API/API_GetUserProfile.php?u={args.username}&y={args.api_key}&z={args.username}"
-
-    start_time = int(time.time())
-
-    RPC = Presence("1249693940299333642")
-    print(Fore.CYAN + "Connecting to Discord App...")
-    RPC.connect()
-    print(Fore.MAGENTA + "Connected!")
-
-    while True:
-        print(Fore.CYAN + f"Fetching {args.username}'s RetroAchievements activity...")
-        data = get_data(profile_url)
-        if data is None:
-            break
-
-        print(Fore.MAGENTA + f"Result: {data['RichPresenceMsg']}")
-
-        game_params = f"?z={args.username}&y={args.api_key}&i={data['LastGameID']}"
-        game_url = f"https://retroachievements.org/API/API_GetGame.php{game_params}"
-        print(Fore.CYAN + "Fetching game data...")
-        game_data = get_data(game_url)
-        if game_data is None:
-            break
-
-        print(Fore.MAGENTA + f"Result: {game_data['GameTitle']}")
-
-        if args.debug:
-            print(Fore.YELLOW + "Debug game data:")
-            pprint(game_data)
-
-        update_presence(RPC, data, game_data, start_time, args)
-
-        print(Fore.CYAN + "Sleeping...")
-        time.sleep(30)
-
-if __name__ == "__main__":
-    main()
+    print(">Sleeping...")
+    time.sleep(30)

--- a/RANes.py
+++ b/RANes.py
@@ -2,6 +2,7 @@ import argparse
 from colorama import Fore, Style, init
 from pprint import pprint
 from pypresence import Presence 
+import re
 import requests
 import time
 
@@ -15,12 +16,18 @@ def get_data(url):
         print(Fore.RED + f"Failed to fetch data from {url}, status code: {response.status_code}")
         return None
 
+def sanitize_console_name(console_name):
+    sanitized_name = re.sub('[^0-9a-zA-Z]+', '', console_name)
+    return sanitized_name.lower()
+
 def update_presence(RPC, data, game_data, start_time):
     details = f"{game_data['GameTitle']} ({game_data['ConsoleName']})"
     RPC.update(
         state=data["RichPresenceMsg"],
         details=details,
         start=start_time,
+        large_image="ra_logo",
+        small_image=sanitize_console_name(game_data['ConsoleName'])
     )
 
 def main():

--- a/RANes.py
+++ b/RANes.py
@@ -1,5 +1,6 @@
 import argparse
 from colorama import Fore, Style, init
+from datetime import datetime
 from pprint import pprint
 from pypresence import Presence 
 import re
@@ -20,21 +21,25 @@ def sanitize_console_name(console_name):
     sanitized_name = re.sub('[^0-9a-zA-Z]+', '', console_name)
     return sanitized_name.lower()
 
-def update_presence(RPC, data, game_data, start_time):
-    details = f"{game_data['GameTitle']} ({game_data['ConsoleName']})"
+def update_presence(RPC, data, game_data, start_time, args):
+    release_date = datetime.strptime(game_data['Released'], '%B %d, %Y')
+    year_of_release = release_date.year
+    details = f"{game_data['GameTitle']} ({year_of_release})"
     RPC.update(
         state=data["RichPresenceMsg"],
         details=details,
         start=start_time,
         large_image="ra_logo",
-        small_image=sanitize_console_name(game_data['ConsoleName'])
+        large_text=f"Released {game_data['Released']}, Developed by {game_data['Developer']}, Published by {game_data['Publisher']}",
+        small_image=sanitize_console_name(game_data['ConsoleName']),
+        small_text=game_data['ConsoleName'],
+        buttons=[{"label": "View RA Profile", "url": f"https://retroachievements.org/user/{args.username}"}]
     )
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('username')
     parser.add_argument('api_key')
-    parser.add_argument('rpc_client_id')
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
 
@@ -42,7 +47,7 @@ def main():
 
     start_time = int(time.time())
 
-    RPC = Presence(args.rpc_client_id)
+    RPC = Presence("1249693940299333642")
     print(Fore.CYAN + "Connecting to Discord App...")
     RPC.connect()
     print(Fore.MAGENTA + "Connected!")
@@ -68,7 +73,7 @@ def main():
             print(Fore.YELLOW + "Debug game data:")
             pprint(game_data)
 
-        update_presence(RPC, data, game_data, start_time)
+        update_presence(RPC, data, game_data, start_time, args)
 
         print(Fore.CYAN + "Sleeping...")
         time.sleep(30)

--- a/RARPC.py
+++ b/RARPC.py
@@ -1,0 +1,89 @@
+import argparse
+from colorama import Fore, Style, init
+import configparser
+from datetime import datetime
+from pprint import pprint
+from pypresence import Presence 
+import re
+import requests
+import time
+
+init(autoreset=True)
+
+def get_data(url):
+    response = requests.get(url)
+    if response.status_code == 200:
+        return response.json()
+    else:
+        print(Fore.RED + f"Failed to fetch data from {url}, status code: {response.status_code}")
+        return None
+
+def sanitize_console_name(console_name):
+    sanitized_name = re.sub('[^0-9a-zA-Z]+', '', console_name)
+    return sanitized_name.lower()
+
+def update_presence(RPC, data, game_data, start_time, username):
+    release_date = datetime.strptime(game_data['Released'], '%B %d, %Y')
+    year_of_release = release_date.year
+    details = f"{game_data['GameTitle']} ({year_of_release})"
+    RPC.update(
+        state=data["RichPresenceMsg"],
+        details=details,
+        start=start_time,
+        large_image="ra_logo",
+        large_text=f"Released {game_data['Released']}, Developed by {game_data['Developer']}, Published by {game_data['Publisher']}",
+        small_image=sanitize_console_name(game_data['ConsoleName']),
+        small_text=game_data['ConsoleName'],
+        buttons=[{"label": "View RA Profile", "url": f"https://retroachievements.org/user/{username}"}]
+    )
+
+def main():
+    config = configparser.ConfigParser()
+    config.read('config.ini')
+    
+    username = config.get('DISCORD', 'username')
+    api_key = config.get('DISCORD', 'api_key')
+    client_id = config.get('DISCORD', 'client_id') if config.has_option('DISCORD', 'client_id') else "1249693940299333642"
+    
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', action='store_true', help='Print debug information')
+    parser.add_argument('--fetch', type=int, default=30, help='Time to sleep before fetches in seconds')
+    args = parser.parse_args()
+
+    profile_url = f"https://retroachievements.org/API/API_GetUserProfile.php?u={username}&y={api_key}&z={username}"
+
+    start_time = int(time.time())
+
+    RPC = Presence(client_id)
+    print(Fore.CYAN + "Connecting to Discord App...")
+    RPC.connect()
+    print(Fore.MAGENTA + "Connected!")
+
+    while True:
+        print(Fore.CYAN + f"Fetching {username}'s RetroAchievements activity...")
+        data = get_data(profile_url)
+        if data is None:
+            break
+
+        print(Fore.MAGENTA + f"Result: {data['RichPresenceMsg']}")
+
+        game_params = f"?z={username}&y={api_key}&i={data['LastGameID']}"
+        game_url = f"https://retroachievements.org/API/API_GetGame.php{game_params}"
+        print(Fore.CYAN + "Fetching game data...")
+        game_data = get_data(game_url)
+        if game_data is None:
+            break
+
+        print(Fore.MAGENTA + f"Result: {game_data['GameTitle']}")
+
+        if args.debug:
+            print(Fore.YELLOW + "Debug game data:")
+            pprint(game_data)
+
+        update_presence(RPC, data, game_data, start_time, username)
+
+        print(Fore.CYAN + f"Sleeping for {args.fetch} seconds...")
+        time.sleep(args.fetch)
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -1,18 +1,11 @@
 # RetroAchievements-Discord-Presence
 
-I made this script because I found no simple way to have my RetroAchievements rich presence tracked on discord's rich Presence
-
-A tutorial will follow up, with hopefully some QoL to make it even easier for users to use this script.
+This is a complete rewrite and extension of [XtremePrime's](https://github.com/XtremePrime) [RetroAchievements-Discord-Presence](https://github.com/XtremePrime/RetroAchievements-Discord-Presence) script.
 
 ## Requirements
 
-- Python3
-- requests (https://pypi.org/project/requests/)
-- pypresence (https://pypi.org/project/pypresence/)
-- Discord Application (for the discord client ID)
+Will update this section later!
 
 ## Running the script
 
-The first argument of your python call should be your Username, then your API_KEY, then your Discord Application Client ID
-- Format: *python RANes.py [Username] [API_KEY] [DISCORD_CLIENT_ID]*
-- Example: *python RANes.py AverageUser 0X0X0X0X0X0X0X0X 123456789*
+Will update this section later!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-colorama
-pypresence
-requests
+colorama>=0.4.4
+configparser>=5.0.2
+pypresence>=4.2.0
+requests>=2.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+colorama
+pypresence
+requests

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d %~dp0
+python RARPC.py


### PR DESCRIPTION
Hey there,

Like yourself I was looking for a way to display my RA RPC as my Discord RPC and was shocked to find there was only 1 attempt, from what I could see. Well, your work inspired me to expand on it a bit, and it ended up spiraling out of control into its own thing, which is why I'm including it as a separate file.

I completely understand if you have no desire to accept this pull as a new base as some of the changes may not be to your taste, but seeing as I've based this off of your work I thought it would be polite to at least offer. I've made the following changes.

1. RANes has been renamed to RARPC.
2. Code refactoring - reworked the code to be more modular and easier to maintain.
3. Removed the username, api key, and client id launch parameters.
4. Config file - Username and API key are set in a config file to make it easier to re run the script.
5. Optional Client ID - To make it easier for the average user, it will use a pre-set client ID unless overridden with `client_id = ` in the config file. This client ID it set to a discord application I have set up named "RetroAchievements", that is pre loaded with assets for the script.
6. Images - the script now assigns a large_image named ra_logo, and the small_image will change to the RA icon of whatever console you're playing.
7. Console name sanitization for assigning the small_image. "PC Engine/TurboGrafx-16" will become "pcengineturbografx16". All 52 consoles have images with the default client id.
8. Mousing over the small_image will display the name of the console. [Preview](https://cdn.discordapp.com/attachments/1240937496590684192/1249929320160301136/Discord_mhysAhQpWH.png?ex=666916e4&is=6667c564&hm=62093736e3f013158754e95a3d9e68ac98bfd788057330728c0f8feb11db38fe&)
9. Mousing over the large_image will display the release date, developer, and publisher. [Preview](https://cdn.discordapp.com/attachments/857072197088051220/1249892587654086697/image.png?ex=6668f4ae&is=6667a32e&hm=02a37493405a288f87fef8e34f88eb74f93e52c6b94a9947f95d30c5bace6a7b&)
10. Game year is displayed next to game name.
11. Play time added, starts counting up when the script is launched.
12. "Open RA Profile" button that [other users can see](https://cdn.discordapp.com/attachments/1240937496590684192/1249928643547893831/image.png?ex=66691643&is=6667c4c3&hm=5c59ed2e10ce19a4dc846c26fd1c395f3b4a5c171c1de87e9a87d000e1799bd7&), clicking on it will open the users RA profile.
13. Improved error handling.
14. New launch arguments, `--debug` will print game_data info to the console when fetching, and "--fetch x" with x being how many seconds you want to wait between fetches. if no --fetch is provided, it will use the default of 30 seconds between fetches.
15. Tells you how long the script is sleeping for between fetches.

And I think that's about it! Thanks for creating the original script, I hope you like my additions, and if not, no hard feelings, I'll keep updating my own fork. :) 

config.ini example:

```
[DISCORD]
; This is your RA username
username = USERNAME HERE

; This is your RA api key
api_key = API KEY HERE

; The client_id is NOT required unless self-hosting.
; It uses a pre-configured client_id by default.
; This is your discord application's oath2 client_id.
; You can get this from the discord developer portal.

; client_id = 
